### PR TITLE
FIX Ensure at least silverstripe/vendor-plugin 1.5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,9 +318,12 @@ jobs:
             composer require $MATRIX_COMPOSER_REQUIRE_EXTRA --no-update
           fi
 
-          # Ensure composer.json has prefer-stable true and minimum-stability dev
-          # Update preferred-install to source for recipes and some modules that run
-          # other unit-tests in other modules
+          # a) Ensure composer.json has prefer-stable true and minimum-stability dev
+          # b) Update preferred-install to source for recipes and some modules that run
+          #    other unit-tests in other modules
+          # c) Prevent installation of silverstripe/vendor-plugin < 1.5.2 which contains a bugfix
+          #    which is required for --prefer-lowest to install
+          #    https://github.com/silverstripe/vendor-plugin/pull/49
           php -r '
             $j = json_decode(file_get_contents("composer.json"));
             $j->{"prefer-stable"} = true;
@@ -338,6 +341,10 @@ jobs:
             $j->config->{"preferred-install"}->{"cwp/*"} = "source";
             $j->config->{"preferred-install"}->{"tractorcow/*"} = "source";
             $j->config->{"preferred-install"}->{"*"} = "dist";
+            if (empty($j->conflict)) {
+              $j->conflict = new stdClass();
+            }
+            $j->conflict->{"silverstripe/vendor-plugin"} = "<1.5.2";
             file_put_contents("composer.json", json_encode($j, JSON_PRETTY_PRINT + JSON_UNESCAPED_SLASHES));
           '
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/11

Ensure we have at least 1.5.2 of vendor plugin on CI so that we have this fix to resolve this issue when running a `--prefer-lowest` job

`Error: Could not read /home/runner/work/silverstripe-framework/silverstripe-framework/vendor/ralouphie/getallheaders/composer.json`

I have also made a corresponding update in framework to [require ^1.6](https://github.com/silverstripe/silverstripe-framework/pull/10360/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R38) - though that's target `4.x-dev`, this `conflict` will resolve issues when running CI on pre 4.12 lines e.g. 4.10
