### PR TITLE
FIX Detect COMPOSER_ROOT_VERSION on push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,12 +263,25 @@ jobs:
           if [[ $GITHUB_BASE_REF != "" ]]; then
             BRANCH_OR_TAG=$GITHUB_BASE_REF
           fi
-          if [[ $BRANCH_OR_TAG =~ ^[1-9]$ ]] || [[ $BRANCH_OR_TAG =~ ^[0-9]\.[0-9]+$ ]]; then
-            export COMPOSER_ROOT_VERSION="${BRANCH_OR_TAG}.x-dev"
+          # This extracts the version from common branch naming conventions
+          # pulls/x/mybranch style is used on push events to creative-commoners account
+          # 4 => 4
+          # 4.10 => 4.10
+          # pulls/4/mybranch => 4
+          # pulls/4.10/mybranch => 4.10
+          if [[ $BRANCH_OR_TAG =~ ^([1-9]+)$ ]] || \
+             [[ $BRANCH_OR_TAG =~ ^([0-9]+\.[0-9]+)$ ]] || \
+             [[ $BRANCH_OR_TAG =~ ^pulls/([1-9]+)/.+$ ]] || \
+             [[ $BRANCH_OR_TAG =~ ^pulls/([0-9]+\.[0-9]+)/.+$ ]]; \
+          then
+            export COMPOSER_ROOT_VERSION="${BASH_REMATCH[1]}.x-dev"
           elif [[ $BRANCH_OR_TAG =~ ^[0-9]\.[0-9]+\.[0-9]+ ]]; then
             export COMPOSER_ROOT_VERSION="${BRANCH_OR_TAG}"
           else
-            export COMPOSER_ROOT_VERSION="dev-${BRANCH_OR_TAG}"
+            # e.g. push event to branch called myaccount-patch-1
+            # use git history to make a best attempt at getting the parent branch
+            PARENT_BRANCH=$(git show-branch -a 2>/dev/null | grep '\*' | grep -v `git rev-parse --abbrev-ref HEAD` | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//')
+            export COMPOSER_ROOT_VERSION="${PARENT_BRANCH}.x-dev"
           fi
           echo "BRANCH_OR_TAG is $BRANCH_OR_TAG"
           echo "COMPOSER_ROOT_VERSION is $COMPOSER_ROOT_VERSION"


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/11

Push events to forked repos are causing `COMPOSER_ROOT_VERSION` to be something like `dev-pulls/1.10/module-standards`, instead of `1.10`

This causes issues if the module being tested is included as part of composer requiring silverstripe/installer

[example](https://github.com/creative-commoners/silverstripe-versioned-admin/runs/7141154577?check_suite_focus=true#step:9:251)

`- silverstripe/recipe-cms 4.10.x-dev requires silverstripe/versioned-admin 1.10.x-dev -> satisfiable by silverstripe/versioned-admin[1.10.x-dev] from composer repo (https://repo.packagist.org/) but silverstripe/versioned-admin is the root package and cannot be modified.`

This PR makes a go at better detection of `COMPOSER_ROOT VERSION`

The regex can be manually validated with

```
for V in \
    4 \
    4.10 \
    4.10.1 \
    burger \
    pulls/4/abc \
    pulls/4.10/abc \
    pulls/4.10.1/abc \
    pulls/burger/abc \
;do
    BRANCH_OR_TAG=$V
    if [[ $BRANCH_OR_TAG =~ ^([1-9]+)$ ]] || \
        [[ $BRANCH_OR_TAG =~ ^([0-9]+\.[0-9]+)$ ]] || \
        [[ $BRANCH_OR_TAG =~ ^pulls/([1-9]+)/.+$ ]] || \
        [[ $BRANCH_OR_TAG =~ ^pulls/([0-9]+\.[0-9]+)/.+$ ]]; \
    then
        COMPOSER_ROOT_VERSION="${BASH_REMATCH[1]}.x-dev"
    elif [[ $BRANCH_OR_TAG =~ ^[0-9]\.[0-9]+\.[0-9]+ ]]; then
        COMPOSER_ROOT_VERSION="${BRANCH_OR_TAG}"
    else
        COMPOSER_ROOT_VERSION="dev-${BRANCH_OR_TAG}"
    fi
    echo $COMPOSER_ROOT_VERSION
done
```