### PR TITLE
FIX Use correct repo name for silverstripe-spellcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
             sudo apt install -y libapache2-mod-php${{ matrix.php }}
             # ubuntu-latest comes with a current version of google-chrome-stable and chromedriver
           fi
-          if [[ $GITHUB_REPOSITORY =~ /(spellcheck|recipe-authoring-tools)$ ]] || [[ "${{ matrix.phpunit_suite }}" == "recipe-authoring-tools" ]]; then
+          if [[ $GITHUB_REPOSITORY =~ /(silverstripe-spellcheck|recipe-authoring-tools)$ ]] || [[ "${{ matrix.phpunit_suite }}" == "recipe-authoring-tools" ]]; then
             sudo apt install -y hunspell libhunspell-dev hunspell-en-us
           fi
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/11

Ensure hunspell is installed for silverstripe-spellcheck, currently it is not

https://github.com/creative-commoners/silverstripe-spellcheck/runs/7191525930?check_suite_focus=true
