### PR TITLE
FIX Increase health retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           MYSQL_DATABASE: SS_mysite
         ports:
           - 3357:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=10
       mysql80:
         image: mysql:8.0
         env:
@@ -124,12 +124,12 @@ jobs:
           MYSQL_DATABASE: SS_mysite
         ports:
           - 3380:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=10
       postgres:
         image: postgres
         env:
           POSTGRES_PASSWORD: postgres
-        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=5
+        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=10
         ports:
           - 5432:5432
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/11

I've seen quite a lot of sporadic job failures due to unhealthy databases

Example

```
Waiting for all services to be ready
  /usr/bin/docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" 18ea2fbb88191054825fb20d90a099b366ea97c619d67f0dbbf3cb45b9fb9c90
  unhealthy
```
https://github.com/creative-commoners/silverstripe-admin/runs/7194459514?check_suite_focus=true

It's not limited to mysql57.  I've seen examples online with health-retries set to 10 so increasing for all databases to see if this helps resolve
