### PR TITLE
FIX Attempt to require multiple versions of silverstripe/installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,11 +314,6 @@ jobs:
             }
           '
 
-          # Require silverstripe/installer for non-recipe and all but a few modules
-          if [[ "${{ matrix.installer_version }}" != "" ]]; then
-            composer require silverstripe/installer:${{ matrix.installer_version }} --no-update
-          fi
-          
           # Required for any module/recipe that runs silverstripe/assets unit tests
           # Should technically be defined as composer_require_extra on individual modules, though easier just doing here
           # 1.6.10 is for --prefer-lowest and is the minimum version with php 8.1 support
@@ -333,6 +328,13 @@ jobs:
           if [[ "${{ matrix.phplinting }}" == "true" ]]; then
             composer require silverstripe/cow:dev-master --dev --no-update
           fi
+
+          # Require silverstripe/installer for non-recipes and all but a few modules
+          # Note: this block needs to be above COMPOSER_REQUIRE_EXTRA to allow that to override what is set here
+          if [[ "${{ matrix.installer_version }}" != "" ]]; then
+            composer require silverstripe/installer:${{ matrix.installer_version }} --no-update
+          fi
+
           if [[ $INPUTS_COMPOSER_REQUIRE_EXTRA != "" ]]; then
             # $INPUTS_COMPOSER_REQUIRE_EXTRA is explicitly not wrapped in double quotes below
             # so that multiple requirements separated by spaces will work
@@ -379,12 +381,74 @@ jobs:
           composer config allow-plugins.silverstripe/recipe-plugin true
           composer config allow-plugins.silverstripe/vendor-plugin true
 
-          # Useful to see generated composer.json when diagnosing new bugs
-          cat composer.json
-
           # matrix.composer_args sometimes includes `--prefer-lowest` which is only supported by `composer update`, not `composer install`
           # Modules do not have composer.lock files, so `composer update` is the same speed as `composer install`
-          composer update --no-interaction --no-progress ${{ matrix.composer_args }}
+          # `|| :` prevents an exit code on a failed composer update from halting the workflow
+          composer update --no-interaction --no-progress ${{ matrix.composer_args }} 2> __update_attempt.txt || :
+
+          if ! [[ $(cat __update_attempt.txt) =~ Problem ]]; then
+            # Succesfully ran composer update and installed everything
+            rm __update_attempt.txt
+            # Useful to see generated composer.json when diagnosing new bugs
+            cat composer.json
+          elif ! [[ $(cat __update_attempt.txt) =~ 'Root composer.json requires silverstripe/installer' ]] || \
+            [[ $INPUTS_COMPOSER_REQUIRE_EXTRA =~ silverstripe/installer ]] || \
+            [[ $MATRIX_COMPOSER_REQUIRE_EXTRA =~ silverstripe/installer ]] || \
+            ! [[ "${{ matrix.installer_version }}" =~ ^[1-9]\.[0-9]+\.x\-dev$ ]]
+          then
+            # Failed to run composer update and will not attempt requiring different versions of silverstripe/installer
+            cat composer.json
+            cat __update_attempt.txt
+            # Using exit code 2 as it's the same code that composer uses when it fails
+            exit 2
+          elif [[ "${{ matrix.installer_version }}" =~ ^([1-9])\.([0-9]+)\.x\-dev$ ]]; then
+            # gha-generate-matrix will not always provide a compatibile version of silverstripe/installer due to
+            # limitations of knowing what versions of silverstripe/installer the pushed code is compatible with
+            # In this scenario we will usually end up with the latest minor x.dev version of silverstripe installer
+            # If it initially failed on composer update, try some earlier versions of silverstripe/installer
+            echo "Could not run composer update with version of silverstripe/installer, attempting earlier versions"
+            MAJOR=${BASH_REMATCH[1]}
+            MINOR=${BASH_REMATCH[2]}
+            SUCCESSFULLY_REQUIRED='false'
+            for MI in $(( MINOR - 1 )) $(( MINOR - 2 )); do
+              if [[ $SUCCESSFULLY_REQUIRED == 'false' ]]; then
+                # Test if $MI is a negative number
+                if [[ $MI =~ - ]]; then
+                  cat composer.json
+                  if [[ -f _require_attempt.txt ]]; then
+                    cat __require_attempt.txt
+                  else
+                    cat __update_attempt.txt
+                  fi
+                  echo 'Have run out of silverstripe/installer versions to attempt to require'
+                  exit 2
+                else
+                  VERSION="$MAJOR.$MI.x-dev"
+                  echo "Attempting to require silverstripe/installer $VERSION"
+                  composer require silverstripe/installer:$VERSION 2> __require_attempt.txt || :
+                  if ! [[ $(cat __require_attempt.txt) =~ Problem ]]; then
+                    SUCCESSFULLY_REQUIRED='true'
+                    echo "Succesfully required silverstripe/installer $VERSION"
+                    rm __require_attempt.txt
+                    cat composer.json
+                  else
+                    echo "Failed to require silverstripe/installer $VERSION"
+                  fi
+                fi
+              fi
+            done
+            if [[ SUCCESSFULLY_REQUIRED == 'false' ]]; then
+              cat composer.json
+              cat __require_attempt.txt
+              exit 2
+            fi
+            rm __update_attempt.txt
+          else
+            # composer update failed for other reasons
+            cat composer.json
+            cat __update_attempt.txt
+            exit 2
+          fi
 
           # Useful to see what was installed
           composer show


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/11

Solve the issue where modules attempt to use an incompatible version of silverstripe/installer on push events. Example
https://github.com/creative-commoners/cwp-core/runs/7190501001?check_suite_focus=true

Example of this successfully falling back to use silverstripe/installer 4.10.x-dev after first failing with 4.11.x-dev
https://github.com/emteknetnz/cwp-core/runs/7228030181?check_suite_focus=true
