### PR TITLE
FIX Allow installing guzzle 6 compatible version of cow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,7 +326,8 @@ jobs:
             composer require silverstripe/recipe-testing:^2 --dev --no-update
           fi
           if [[ "${{ matrix.phplinting }}" == "true" ]]; then
-            composer require silverstripe/cow:dev-master --dev --no-update
+            # cow ~2.0 support guzzle 6 so is installable on older branches, dev-master supports guzzle 7
+            composer require "silverstripe/cow:~2.0 || dev-master" --dev --no-update
           fi
 
           # Require silverstripe/installer for non-recipes and all but a few modules
@@ -437,7 +438,7 @@ jobs:
                 fi
               fi
             done
-            if [[ SUCCESSFULLY_REQUIRED == 'false' ]]; then
+            if [[ $SUCCESSFULLY_REQUIRED == 'false' ]]; then
               cat composer.json
               cat __require_attempt.txt
               exit 2


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/11

Some older branches on modules define guzzle 6 in their composer.json.  This change allows the installation of an older version of cow that uses guzzle 6.  cow is used for `vendor/bin/cow schema:validate` in the phplinting test if the module has a `.cow.json` file

Example of an older version of a module that uses guzzle 6 - https://github.com/silverstripe/silverstripe-ckan-registry/blob/1.4/composer.json#L24