### PR TITLE
FIX Use correct repository for postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
           # 1.6.10 is for --prefer-lowest and is the minimum version with php 8.1 support
           composer require mikey179/vfsstream:^1.6.10 --dev --no-update
 
-          if [[ "${{ matrix.db }}" == "pgsql" ]] && ! [[ $GITHUB_REPOSITORY =~ /postgresql ]]; then
+          if [[ "${{ matrix.db }}" == "pgsql" ]] && ! [[ $GITHUB_REPOSITORY =~ /silverstripe-postgresql ]]; then
             composer require silverstripe/postgresql:^2 --no-update
           fi
           if [[ "${{ matrix.endtoend }}" == "true" ]]; then


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/11

Fixes
`Root package 'silverstripe/postgresql' cannot require itself in its composer.json`
https://github.com/creative-commoners/silverstripe-postgresql/runs/7242198640?check_suite_focus=true