### PR TITLE
FIX Disable xdebug extension if not running phpcoverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
 
           # Disable xdebug which greatly slow down unit testing
           # Note: omitting xdebug from shivammathur/setup-php still results in xdebug being installed and enabled
-          if [[ "${{ matrix.phpcoverage }}" == "true" ]]; then
+          if [[ "${{ matrix.phpcoverage }}" != "true" ]]; then
             sudo sh -c "echo ';zend_extension=xdebug.so' > /etc/php/${{ matrix.php }}/mods-available/xdebug.ini"
           fi
           echo "PHP has been configured"


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Should fix 60 second timeout https://github.com/silverstripe/recipe-kitchen-sink/runs/7509621401?check_suite_focus=true