### PR TITLE
FIX Allow CMS 5 compatible version of recipe-testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
             composer require silverstripe/postgresql:^2 --no-update
           fi
           if [[ "${{ matrix.endtoend }}" == "true" ]] && ! [[ $GITHUB_REPOSITORY =~ /recipe-testing$ ]]; then
-            composer require silverstripe/recipe-testing:^2 --dev --no-update
+            composer require "silverstripe/recipe-testing:^2 || ^3" --dev --no-update
           fi
           if [[ "${{ matrix.phplinting }}" == "true" ]] && [[ -f .cow.json ]] && ! [[ $GITHUB_REPOSITORY =~ /cow$ ]]; then
             # cow ~2.0 support guzzle 6 so is installable on older branches, dev-master supports guzzle 7


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10349

Fix https://github.com/silverstripe/silverstripe-cms/runs/7737427352?check_suite_focus=true
```
  Problem 1
    - silverstripe/recipe-testing[2.0.0, ..., 2.x-dev] require silverstripe/framework ^4.10 -> found silverstripe/framework[4.10.0-beta1, ..., 4.x-dev] but it conflicts with your root composer.json require (^5).
    - Root composer.json requires silverstripe/recipe-testing ^2 -> satisfiable by silverstripe/recipe-testing[2.0.0, 2.0.x-dev, 2.x-dev].
```