### PR TITLE
FIX Don't try to create a file in non-existent dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,7 +555,8 @@ jobs:
           cat .env
 
           # silverstripe logging
-          cat << EOF >> app/_config/my-logger.yml
+          if [[ -d "./app/_config/" ]]; then
+            cat << EOF >> app/_config/my-logger.yml
           ---
           Name: error-logging
           After: '*'
@@ -570,6 +571,7 @@ jobs:
                 - "$GITHUB_WORKSPACE/silverstripe.log"
                 - "notice"
           EOF
+          fi
 
           # Artifacts directory must be created after composer install as it would remove the artifacts directory
           # This seems a bit strange, if you need to add an artifact at an earlier stage then revalidate that


### PR DESCRIPTION
For repos that shouldn't have silverstripe installed, there is no `app/_config/` dir, so trying to add the logger file fails which fails all of CI for that repo.

Fixes https://github.com/silverstripe/recipe-plugin/actions/runs/3112592017/jobs/5046185906 and https://github.com/silverstripe/vendor-plugin/actions/runs/3121990573
> /home/runner/work/_temp/a239a952-5053-4524-97ce-14be186dce5a.sh: line 45: app/_config/my-logger.yml: No such file or directory

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/594