### PR TITLE
ENH Set logger to "debug" so deprecations show

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,7 +587,7 @@ jobs:
               class: Monolog\Handler\StreamHandler
               constructor:
                 - "$GITHUB_WORKSPACE/silverstripe.log"
-                - "notice"
+                - "debug"
           EOF
           fi
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10542
Other issue https://github.com/silverstripe/gha-ci/issues/53

I don't think there's any real downside since the silverstripe.log file never seems to show in the artifacts anyway even on red builds. There's more disk space used for artifacts, though I'd imagine that we're still far below whatever the quota is.
