### PR TITLE
ENH Add support for testing alternative SQLite and preserving vendor test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ on:
       js:
         type: boolean
         default: true
+      preserve_vendor_tests:
+        type: boolean
+        default: false
+        description: Whether tests in the vendor folder should be preserved.
 
 jobs:
 
@@ -256,7 +260,8 @@ jobs:
           path: ~/.cache/composer
           key: shared-composer-cache
 
-      # Update composer.json and install dependencies
+      # Update composer.json and install dependencies such as Databases binaries to run the tests
+      # Note that SQLite3 doesn't need to be installed because it is bundle in the GitHub docker image.
       - name: Composer
         env:
           INPUTS_COMPOSER_REQUIRE_EXTRA: ${{ inputs.composer_require_extra }}
@@ -360,6 +365,9 @@ jobs:
 
             if [[ "${{ matrix.db }}" == "pgsql" ]] && ! [[ $GITHUB_REPOSITORY =~ /silverstripe-postgresql$ ]]; then
               composer require "silverstripe/postgresql:^2 || ^3" --no-update
+            fi
+            if [[ "${{ matrix.db }}" == "sqlite3" ]] && ! [[ $GITHUB_REPOSITORY =~ /silverstripe-sqlite3$ ]]; then
+              composer require "silverstripe/sqlite3:^2 || ^3" --no-update
             fi
             if [[ "${{ matrix.endtoend }}" == "true" ]] && ! [[ $GITHUB_REPOSITORY =~ /recipe-testing$ ]]; then
               composer require "silverstripe/recipe-testing:^2 || ^3" --dev --no-update
@@ -485,7 +493,8 @@ jobs:
           # Some older silverstripe vendor modules may still have the phpunit5 setUp() signatures without :void which when loaded will throw fatal PHP errors.
           # We cannot simply get rid of the 'tests' folders because behat requires vendor/silverstripe/[framework|cms]/tests/behat/serve-bootstrap.php
           # Recipes are excluded because the unit tests they run are in the required modules, and there's an assumption they'll require a compatible minor branch of the module
-          if ! [[ $GITHUB_REPOSITORY =~ /(recipe|silverstripe-installer) ]]; then
+
+          if [[ "${{ inputs.preserve_vendor_tests }}" == "false" ]] && ! [[ $GITHUB_REPOSITORY =~ /(recipe|silverstripe-installer) ]]; then
             echo "Repositiory is a not a recipe, removing unecessary vendor silverstripe unit tests"
             # Make an exception for 'ExtendTest.php' which is a misnamed TestOnly non-test class
             php -r '
@@ -551,13 +560,20 @@ jobs:
           SS_DATABASE_USERNAME="root"
           SS_DATABASE_PASSWORD="root"
           EOF
-          else
+          elif [[ "${{ matrix.db }}" =~ pgsql ]]; then
             cat << EOF > .env
           SS_DATABASE_CLASS="PostgreSQLDatabase"
           SS_DATABASE_SERVER="localhost"
           SS_DATABASE_PORT="5432"
           SS_DATABASE_USERNAME="postgres"
           SS_DATABASE_PASSWORD="postgres"
+          EOF
+          elif [[ "${{ matrix.db }}" =~ sqlite3 ]]; then
+            cat << EOF > .env
+          SS_DATABASE_CLASS="SQLite3Database"
+          SS_DATABASE_USERNAME="root"
+          SS_DATABASE_PASSWORD=""
+          SS_SQLITE_DATABASE_PATH=":memory:'"
           EOF
           fi
           cat << EOF >> .env

--- a/README.md
+++ b/README.md
@@ -122,13 +122,22 @@ The version of PHP to run e.g. 8.1
 ###### db
 The database to run e.g. mysql80
 
-For the list of supported databases see [the gha-generate-matrix script](https://github.com/silverstripe/gha-generate-matrix/blob/main/job_creator.php)
+Valid `db` are:
+- pgsql
+- mysql57
+- mysql80
+- sqlite3
 
 ###### name_suffix
 Add a specific suffix to job and artifact names to make them easier to identify. This will be trucated if greater than 20 characters. Must match the regex `[a-zA-Z0-9_\- ]`
 
 ###### phpunit_suite
 The PHPUnit suite to run as defined in `phpunit.xml`. Translates to the `--testsuite` parameter passed to `phpunit`. Specify 'all' to run all PHPunit suites available in the context of this module/recipe
+
+###### preserve_vendor_tests
+By default, the workflow will want try to delete tests for modules in the `vendor` folder to avoid potential conflicts with tests rewritten for different PHPUnit versions. This behaviour is not always desirable because you may want to run those tests for your current build.
+
+Setting this input to `true` will preserve tests in the vendor folder.
 
 ###### endtoend_suite
 The end-to-end suite as defined in `behat.yml`. Must be defined, specify 'root' to run the default suite


### PR DESCRIPTION
This PRs add the following enhancements:
- Adds an options to preserve vendor test
- Adds support for sqlite3
- Add a step to explicitly validates that your db is valid

# Parent issues
- https://github.com/silverstripe/silverstripe-sqlite3/issues/68
- https://github.com/silverstripe/silverstripe-postgresql/issues/143