### PR TITLE
ENH Remove cow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,10 +387,6 @@ jobs:
             if [[ "${{ matrix.endtoend }}" == "true" ]] && ! [[ $GITHUB_REPOSITORY =~ /recipe-testing$ ]]; then
               composer require "silverstripe/recipe-testing:^2 || ^3" --dev --no-update
             fi
-            if [[ "${{ matrix.phplinting }}" == "true" ]] && [[ -f .cow.json ]] && ! [[ $GITHUB_REPOSITORY =~ /cow$ ]]; then
-              # cow ~2.0 support guzzle 6 so is installable on older branches, dev-master supports guzzle 7
-              composer require "silverstripe/cow:~2.0 || dev-master" --dev --no-update
-            fi
 
             # Require silverstripe/installer for non-recipes and all but a few modules
             # Note: this block needs to be above COMPOSER_REQUIRE_EXTRA to allow that to override what is set here


### PR DESCRIPTION
We shouldn't be doing cow linting in CI - it belongs as part of the release process.
Companion to https://github.com/silverstripe/gha-run-tests/pull/12

Fixes https://github.com/silverstripe/recipe-solr-search/actions/runs/4262437888/jobs/7493366539
cow cannot install with some of the other dependencies.

## Parent issue
- https://github.com/silverstripe/.github/issues/6