### PR TITLE
DEP Update dependencies to avoid deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,11 +151,11 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2.4.2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: Install PHP
         # SHA will need to be updated to support new php version when they are released
-        uses: shivammathur/setup-php@3eda58347216592f618bb1dff277810b6698e4ca # v2.19.1
+        uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # v2.22.0
         with:
           php-version: ${{ matrix.php }}
           extensions: curl, dom, gd, intl, json, ldap, mbstring, mysql, tidy, xdebug, zip
@@ -278,7 +278,7 @@ jobs:
       # need to download requirements for the first time, after that it will be plenty quick
       # https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows
       - name: Enable shared composer cache
-        uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed # @v2.1.7
+        uses: actions/cache@2b250bc32ad02700b996b496c14ac8c2840a2991 # @v2.1.8
         with:
           path: ~/.cache/composer
           key: shared-composer-cache
@@ -707,7 +707,7 @@ jobs:
 
       # https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
       - name: Upload artifacts
-        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # @v2.3.1
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # @v3.1.2
         if: always()
         with:
           name: ${{ env.artifacts_name }}


### PR DESCRIPTION
Updated dependencies to avoid deprecated `save-state` and `set-output`
These versions all use `@actions/core` `v1.10.0` or greater as per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Issue
- https://github.com/silverstripe/.github/issues/26