### PR TITLE
ENH Remove apostrophe in :memory: value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -615,7 +615,7 @@ jobs:
           SS_DATABASE_CLASS="SQLite3Database"
           SS_DATABASE_USERNAME="root"
           SS_DATABASE_PASSWORD=""
-          SS_SQLITE_DATABASE_PATH=":memory:'"
+          SS_SQLITE_DATABASE_PATH=":memory:"
           EOF
           fi
           cat << EOF >> .env


### PR DESCRIPTION
There is a stray apostrophe here when I nose around default environment configurations while working on my serverless project.