### PR TITLE
FIX Remove preinstalled psr extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,17 @@ jobs:
           if [[ "${{ matrix.phpcoverage }}" != "true" ]]; then
             sudo sh -c "echo ';zend_extension=xdebug.so' > /etc/php/${{ matrix.php }}/mods-available/xdebug.ini"
           fi
+
+          # Remove php8.x-psr extension which may be pre-installed with ubuntu
+          # The extension adds a PHP PsrExt namespace aliased to Psr and the implementation of
+          # PsrExt\Log\LoggerInterface::emergency() has a signature that conflicts with Monolog\Logger::emergency()
+          match=$(sudo dpkg --get-selections | grep php | grep psr) || true
+          if [[ "$match" =~ ^(php[0-9\.]+\-psr) ]]; then
+            extension=${BASH_REMATCH[1]};
+            sudo apt remove "$extension"
+            echo "Removed PHP extension $extension"
+          fi
+
           echo "PHP has been configured"
 
       - name: Install additional requirements 


### PR DESCRIPTION
Looks like the version of PHP 8.1 that ships with ubuntu now has the php8.1-psr extension with bundled with it, at least the one used in github actions CI.  We do not install this extension using the setup-php github action

That extension causes the following issue php PHP 8.1 builds only

`PHP Fatal error:  Declaration of Monolog\Logger::emergency(Stringable|string $message, array $context = []): void must be compatible with PsrExt\Log\LoggerInterface::emergency($message, array $context = []) in /home/runner/work/silverstripe-userforms/silverstripe-userforms/vendor/monolog/monolog/src/Monolog/Logger.php on line 681`

The solution is to remove the extension - https://github.com/laravel/framework/issues/46165

Example run of this working - https://github.com/emteknetnz/silverstripe-userforms/actions/runs/7121325156/job/19390520149#step:5:81
