### PR TITLE
ENH Use LTS for mariadb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         ports:
           - 5432:5432
       mariadb:
-        image: mariadb:11.2
+        image: mariadb:10.11
         env:
           MARIADB_HOST: 127.0.0.1
           MARIADB_ROOT_PASSWORD: root


### PR DESCRIPTION
MariaDB 11.7 is LTS (search for "long-term" on [the releases page](https://mariadb.com/kb/en/new-and-old-releases/))
MySQL 8.0 is the equivalent of an LTS until 8.4 releases (search for "MySQL Versions Release Cadence" on [the LTS announcement](https://dev.mysql.com/blog-archive/introducing-mysql-innovation-and-long-term-support-lts-versions))

## Issue
- https://github.com/silverstripe/.github/issues/202