### PR TITLE
ENH Test against latest MariaDB LTS release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         ports:
           - 5432:5432
       mariadb:
-        image: mariadb:10.11
+        image: mariadb:11.4
         env:
           MARIADB_HOST: 127.0.0.1
           MARIADB_ROOT_PASSWORD: root


### PR DESCRIPTION
Only CMS 5 (and 6) use MariaDB in their tests, so this is the only change we need.

Targetting `1` since there's a (slim) chance it could break community module CI if they're not able to support the latest LTS. New branch and release need to be created manually after merging.

## Issue
- https://github.com/silverstripe/gha-generate-matrix/issues/85