### PR TITLE
FIX Use double quotes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,7 +611,7 @@ jobs:
               php -r '
                 $j = json_decode(file_get_contents("composer.json"));
                 $v = $j->require->{"silverstripe/installer"};
-                if (strpos($v, '^') === 0) {
+                if (strpos($v, "^") === 0) {
                   $v = str_replace("^", "", $v) . ".x-dev";
                 }
                 $j->require->{"silverstripe/installer"} = $v;


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/132

Can't using single quotes in `php -r '{script}'` block