### PR TITLE
NEW Install extra PHP extensions for some unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ on:
       phpunit:
         type: boolean
         default: true
+      phpunit_skip_suites:
+        type: string
+        required: false
+        default: ''
       js:
         type: boolean
         default: true
@@ -112,6 +116,7 @@ jobs:
           phpcoverage_force_off: ${{ inputs.phpcoverage_force_off }}
           phplinting: ${{ inputs.phplinting }}
           phpunit: ${{ inputs.phpunit }}
+          phpunit_skip_suites: ${{ inputs.phpunit_skip_suites }}
           js: ${{ inputs.js }}
           doclinting: ${{ inputs.doclinting }}
 
@@ -197,6 +202,8 @@ jobs:
           # COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure PHP
+        env:
+          INSTALL_IN_MEMORY_CACHE_EXTS: ${{ matrix.install_in_memory_cache_exts }}
         run: |
           # Set memory limit and disable xdebug if not running phpcoverage
           if [[ -z $(which php) ]]; then
@@ -232,6 +239,13 @@ jobs:
             extension=${BASH_REMATCH[1]};
             sudo apt remove "$extension"
             echo "Removed PHP extension $extension"
+          fi
+
+          if [[ $INSTALL_IN_MEMORY_CACHE_EXTS == 'true' ]]; then
+            sudo apt-get install php${{ matrix.php }}-memcached
+            sudo sh -c "echo 'apc.enable_cli=On' >> /etc/php/${{ matrix.php }}/cli/php.ini"
+            echo 'Installed in-memory cache extensions and set APCu to be enabled'
+            echo 'Note that Redis will be added as a composer dependency'
           fi
 
           echo "PHP has been configured"
@@ -424,6 +438,7 @@ jobs:
         env:
           INPUTS_COMPOSER_REQUIRE_EXTRA: ${{ inputs.composer_require_extra }}
           MATRIX_COMPOSER_REQUIRE_EXTRA: ${{ matrix.composer_require_extra }}
+          INSTALL_IN_MEMORY_CACHE_EXTS: ${{ matrix.install_in_memory_cache_exts }}
           PARENT_BRANCH: ${{ matrix.parent_branch }}
           # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
           # github.base_ref is only available on pull-requests events is the target branch - is is NOT prefixed with refs/heads/
@@ -532,6 +547,9 @@ jobs:
             fi
             if [[ "${{ matrix.endtoend }}" == "true" ]] && ! [[ $GITHUB_REPOSITORY =~ /recipe-testing$ ]]; then
               composer require "silverstripe/recipe-testing:^2 || ^3 || ^4" --dev --no-update
+            fi
+            if [[ $INSTALL_IN_MEMORY_CACHE_EXTS == 'true' ]]; then
+                composer require predis/predis --no-update
             fi
 
             # Require silverstripe/installer for non-recipes and all but a few modules

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Runs linting against documentation using [silverstripe/documentation-lint](https
 Runs PHPunit if the `phpunit.xml` or `phpunit.xml.dist` config file is available. Default is true, disable PHPunit tests with:
 `phpunit: false`
 
+##### Skip PHPUnit suites
+Skips specific PHPUnit suites in the dynamically generated matrix. Default is to run all suites. Configure with:
+`phpunit_skip_suites: suite-to-skip,another-to-skip`
+
 ##### PHP linting
 Runs phpcs and phpstan if the `phpcs.xml.dist` or `phpstan.neon.dist` config files are available. Default is true, disable with:
 `phplinting: false`
@@ -104,7 +108,7 @@ Runs `yarn lint`, `yarn test` and `yarn build` + `git diff-files` + `git diff` i
 `js: false`
 
 ##### Extra jobs
-Define specific test combinations (e.g. php and db versions). All inputs are false by default so you only need to include config for the input(s) you want enabled. All inputs except `dynamic_matrix` and `simple_matrix` are available in this context. There are also some additional inputs specific to the extra_jobs input (see below). Use a multi-line yml string
+Define specific test combinations (e.g. php and db versions). All inputs are false by default so you only need to include config for the input(s) you want enabled. All inputs except `dynamic_matrix`, `simple_matrix`, and `phpunit_skip_suites` are available in this context. There are also some additional inputs specific to the extra_jobs input (see below). Use a multi-line yml string
 ```yml
 extra_jobs: |
   - php: '8.0'
@@ -149,3 +153,6 @@ The end-to-end suite as defined in `behat.yml`. Must be defined, specify 'root' 
 
 ###### endtoend_config
 The `behat.yml` config file to use if not using the root `behat.yml`. Only used if running behat tests in a different module
+
+###### install_in_memory_cache_exts
+Must be true or false. Determines whether to install in-memory cache extensions for framework unit tests.


### PR DESCRIPTION
`install_inmemory_cache_exts` can be set to true in `extra_jobs` - doing so adds the necessary requirements for all three in-memory cache adapters to be checked in the new unit test (see https://github.com/silverstripe/silverstripe-framework/pull/11300/files#diff-c45f7dfcc60b4ba10d58981503d905eb32b9415cb3883f13aae632767dcaf390).

The new `phpunit_skip_suites` input is added so that we can have those extra dependencies only for the unit tests that need them.

We don't actually need to have a memcached or redis server running - we're not testing that the symfony adapters _work_, that's symfony's job. We just need the prerequisites to be met so we can instantiate the adapters, to check the correct adapters _do_ get instantiated.

See https://github.com/GuySartorelli/silverstripe-framework/actions/runs/9850069049/job/27195842069 for a test run which shows this works fine as far as installing everything.
Note that the framework PR requires other PRs to go green, so that's what all the red is about. The important thing is that it gets passed both "Configure PHP" and "Composer", and that only the one extra cache CI run exists.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11145