### PR TITLE
ENH Dispatch patch tag workflow instead of running directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -955,6 +955,7 @@ jobs:
     name: Check governance
     runs-on: ubuntu-latest
     needs: 'genmatrix'
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     outputs:
       can_tag: ${{ steps.check-governance.outputs.can_tag }}
     env:
@@ -1032,33 +1033,43 @@ jobs:
           echo "can_tag output is $CAN_TAG"
           echo "can_tag=$CAN_TAG" >> $GITHUB_OUTPUT
 
-  gaugerelease:
-    name: Check unreleased changes
+  dispatchtagpatchrelase:
+    name: Dispatch tag patch release
     runs-on: ubuntu-latest
     needs: [tests, checkgovernance]
-    if: ${{ needs.checkgovernance.outputs.can_tag == '1' && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
-    outputs:
-      do_release: ${{ steps.gauge-release.outputs.do_release }}
-      next_tag: ${{ steps.gauge-release.outputs.next_tag }}
+    if: ${{ (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && needs.checkgovernance.outputs.can_tag == '1' }}
+    env:
+      GITHUB_REPOSITORY: ${{ github.repository }}
+      BRANCH: ${{ github.ref_name }}
     steps:
-      - name: Gauge release
-        id: gauge-release
-        uses: silverstripe/gha-gauge-release@v1
-        with:
-          latest_local_sha: ${{ needs.tests.outputs.latest_local_sha }}
 
-  patchrelease:
-    name: Patch release
-    runs-on: ubuntu-latest
-    needs: gaugerelease
-    if: ${{ needs.gaugerelease.outputs.do_release == '1' }}
-    permissions:
-      contents: write
-    steps:
-      - name: Patch release
-        uses: silverstripe/gha-tag-release@v1
-        with:
-          tag: ${{ needs.gaugerelease.outputs.next_tag }}
-          delete_existing: false
-          release: true
-          release_auto_notes: true
+      - name: Dispatch tag patch release
+        shell: bash
+        id: dispatch-tag-patch-release
+        run: |
+          if ! [[ -f .github/workflows/tag-patch-release.yml ]]; then
+            echo "tag-patch-release.yml not present. Skipping."
+            exit 0
+          fi
+          # https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
+          RESP_CODE=$(curl -w %{http_code} -s -L -o __response.json \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/tag-patch-release.yml/dispatches \
+            -d "{\"ref\":\"$BRANCH\",\"inputs\":{\"latest_local_sha\":\"${{ needs.tests.outputs.latest_local_sha }}\"}}"
+          )
+          if [[ $RESP_CODE != "204" ]]; then
+            echo "Failed to dispatch workflow - HTTP response code was $RESP_CODE"
+            cat __response.json
+            exit 1
+          fi
+
+      - name: Delete temporary files
+        shell: bash
+        if: always()
+        run: |
+          if [[ -f __response.json ]]; then
+            rm __response.json
+          fi

--- a/README.md
+++ b/README.md
@@ -21,9 +21,14 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   ci:
     name: CI
+    permissions:
+      pull-requests: read
+      contents: read
     uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
 ```
 
@@ -35,9 +40,14 @@ on:
   schedule:
   - cron: '0 0 * * 1'
 
+permissions: {}
+
 jobs:
   ci:
     name: CI
+    permissions:
+      pull-requests: read
+      contents: read
     # Only run the cron on the account hosting this repository, not on the accounts of forks
     # Change '<account_name>' to match the name of the account hosting this repository
     if: (github.event_name == 'schedule' && github.repository_owner == '<account_name>') || (github.event_name != 'schedule')


### PR DESCRIPTION
Dispatches the new workflow added in https://github.com/silverstripe/module-standardiser/pull/66 instead of running patch tagging directly.

This removes the need for `content:write` permissions in `ci.yml`

## Issue
- https://github.com/silverstripe/gha-ci/issues/137