### PR TITLE
FIX Lock chrome and chromedriver to v126 until we know why 127 fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,16 +274,14 @@ jobs:
             # remove old symlink - note /usr/bin/google-chrome-stable is removed by apt remove above
             sudo rm /usr/bin/chromedriver
 
-            # Get latest versions of chrome + chromedriver from json endpoint
-            curl https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json > chrome.json
-
+            # Get last known version of chrome + chromedriver that doesn't differ from actual user experience
             # Install chrome
-            wget $(cat chrome.json | jq -r '.channels.Stable.downloads.chrome[] | select(.platform == "linux64").url')
+            wget https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.182/linux64/chrome-linux64.zip
             unzip chrome-linux64.zip
             sudo ln -s $(pwd)/chrome-linux64/chrome /usr/bin/chrome
 
             # Install chromedriver
-            wget $(cat chrome.json | jq -r '.channels.Stable.downloads.chromedriver[] | select(.platform == "linux64").url')
+            wget https://storage.googleapis.com/chrome-for-testing-public/126.0.6478.182/linux64/chromedriver-linux64.zip
             unzip chromedriver-linux64.zip
             sudo ln -s $(pwd)/chromedriver-linux64/chromedriver /usr/bin/chromedriver
 
@@ -295,7 +293,6 @@ jobs:
             echo "Chromedriver version is: $(chromedriver --version)"
 
             # Remove temporary files
-            rm chrome.json
             rm chrome-linux64.zip
             rm chromedriver-linux64.zip
           fi


### PR DESCRIPTION
As per https://github.com/silverstripe/.github/issues/287#issuecomment-2257340563 the recent version of chromedriver seems to be causing problems in our behat that can't be reproduced directly by user interaction. I [opened an issue about this](https://github.com/php-webdriver/php-webdriver/issues/1104) with `php-webdriver/webdriver` which seems to be what directly drives chromedriver. Hopefully they can resolve it from their end.

In the meantime, this PR locks the version we use to the last version that is known to not have this problem.

I've opened https://github.com/silverstripe/gha-ci/issues/141 to revisit this in a month's time (or if the underlying issue is directly resolved)

## Issue
- https://github.com/silverstripe/.github/issues/287