### PR TITLE
FIX Allow patch tag workflow to be dispatched correctly.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1038,6 +1038,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tests, checkgovernance]
     if: ${{ (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && needs.checkgovernance.outputs.can_tag == '1' }}
+    permissions:
+      actions: write
     env:
       GITHUB_REPOSITORY: ${{ github.repository }}
       BRANCH: ${{ github.ref_name }}
@@ -1047,10 +1049,6 @@ jobs:
         shell: bash
         id: dispatch-tag-patch-release
         run: |
-          if ! [[ -f .github/workflows/tag-patch-release.yml ]]; then
-            echo "tag-patch-release.yml not present. Skipping."
-            exit 0
-          fi
           # https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
           RESP_CODE=$(curl -w %{http_code} -s -L -o __response.json \
             -X POST \
@@ -1060,6 +1058,10 @@ jobs:
             https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/tag-patch-release.yml/dispatches \
             -d "{\"ref\":\"$BRANCH\",\"inputs\":{\"latest_local_sha\":\"${{ needs.tests.outputs.latest_local_sha }}\"}}"
           )
+          if [[ $RESP_CODE == "404" ]]; then
+            echo "tag-patch-release.yml not present."
+            exit 0
+          fi
           if [[ $RESP_CODE != "204" ]]; then
             echo "Failed to dispatch workflow - HTTP response code was $RESP_CODE"
             cat __response.json

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Note: Unlike other silverstripe/gha-* repositories, this one is a [reusable work
 
 Create the following file in your module, and substitute the tagged version for the most recent tag prefixed with a `v` e.g. `@v1`
 
+> [!WARNING]
+> Note that the `actions: write` permission won't be used in third-party repositories, but still needs to be defined. This permission is required because in commercially supported repositories and repositories in the "silverstripe" GitHub organisation we dispatch a separate workflow which tags patch releases.
+
 **.github/workflows/ci.yml**
 ```yml
 name: CI
@@ -29,6 +32,7 @@ jobs:
     permissions:
       pull-requests: read
       contents: read
+      actions: write
     uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
 ```
 
@@ -48,6 +52,7 @@ jobs:
     permissions:
       pull-requests: read
       contents: read
+      actions: write
     # Only run the cron on the account hosting this repository, not on the accounts of forks
     # Change '<account_name>' to match the name of the account hosting this repository
     if: (github.event_name == 'schedule' && github.repository_owner == '<account_name>') || (github.event_name != 'schedule')


### PR DESCRIPTION
Two changes were made here:

1. Don't check for the presence of the file up front. Turns out the `actions/checkout` action is per-job. So we'd have to run that again in this job for it to work. Instead, we can just check the response code of the request, and if it's a 404 we know the file wasn't there.
2. Add the `actions:write` permission. This is required, or else we get a 403 response code.

I have tested this in a repo I control, and found both of these changes are necessary for it to work as expected.

I have also pulled this fork in a repo I control to check and the new permission does need to be added in ci.yml for community members: https://github.com/GuySartorelli/silverstripe-composable-validators/actions/runs/10275469540
I've added back the warning from https://github.com/silverstripe/gha-ci/pull/139#discussion_r1699461419 as a result.

## Issue
- https://github.com/silverstripe/gha-ci/issues/145