### PR TITLE
FIX Use PHP 8.3 compatible version of vfsstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,7 +534,7 @@ jobs:
             # Required for any module/recipe that runs silverstripe/assets unit tests
             # Should technically be defined as composer_require_extra on individual modules, though easier just doing here
             # 1.6.10 is for --prefer-lowest and is the minimum version with php 8.1 support
-            composer require mikey179/vfsstream:^1.6.10 --dev --no-update
+            composer require mikey179/vfsstream:^1.6.11 --dev --no-update
 
             if [[ "${{ matrix.db }}" == "pgsql" ]] && ! [[ $GITHUB_REPOSITORY =~ /silverstripe-postgresql$ ]]; then
               composer require "silverstripe/postgresql:^2 || ^3" --no-update


### PR DESCRIPTION
Needed to fix https://github.com/silverstripe/silverstripe-assets/actions/runs/10447768495/job/28927711730?pr=631
> Creation of dynamic property org\bovigo\vfs\vfsStreamWrapper::$context is deprecated

That's patched explicitly in https://github.com/bovigo/vfsStream/releases/tag/v1.6.11

## Issue
- https://github.com/silverstripe/.github/issues/297