### PR TITLE
FIX Remove `@alpha`, `@beta`, or `@rc` from prefer-lowest installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -628,6 +628,8 @@ jobs:
                 $v = $j->require->{"silverstripe/installer"};
                 if (strpos($v, "^") === 0) {
                   $v = str_replace("^", "", $v) . ".x-dev";
+                  // Remove @beta, @rc, or @alpha if they're there
+                  $v = preg_replace('/@(alpha|beta|rc)/', '', $v);
                 }
                 $j->require->{"silverstripe/installer"} = $v;
                 $c = json_encode($j, JSON_PRETTY_PRINT + JSON_UNESCAPED_SLASHES);
@@ -910,24 +912,27 @@ jobs:
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
         run: |
+          if ! [[ -d artifacts ]]; then
+            mkdir artifacts
+          fi
           # Copy selected files to the artifacts dir
           if [[ -f composer.json ]]; then
-            cp composer.json artifacts
+            cp composer.json artifacts/
           fi
           if [[ -f composer.lock ]]; then
-            cp composer.lock artifacts
+            cp composer.lock artifacts/
           fi
           if [[ "${{ matrix.endtoend }}" == "true" ]] && [[ -f __behat.yml ]]; then
-            cp __behat.yml artifacts
+            cp __behat.yml artifacts/
           fi
           if [[ -f ${APACHE_LOG_DIR}/error.log ]]; then
-            cp ${APACHE_LOG_DIR}/error.log artifacts
+            cp ${APACHE_LOG_DIR}/error.log artifacts/
           fi
           if [[ -f ${APACHE_LOG_DIR}/access.log ]]; then
-            cp ${APACHE_LOG_DIR}/access.log artifacts
+            cp ${APACHE_LOG_DIR}/access.log artifacts/
           fi
           if [[ -f $GITHUB_WORKSPACE/silverstripe.log ]]; then
-            cp $GITHUB_WORKSPACE/silverstripe.log artifacts
+            cp $GITHUB_WORKSPACE/silverstripe.log artifacts/
           fi
 
       # https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts


### PR DESCRIPTION
I *think* this will fix the prefer-lowest build in https://github.com/silverstripe/silverstripe-campaign-admin/actions/runs/10781313032/job/29899010217 and in many other CI runs across sink.

> Could not parse version constraint `5.3@beta.x-dev`: Invalid version string "`5.3@beta.x-dev`"

The output from generate-matrix is correct, and this is only happening for prefer-lowest, so I'm pretty sure this is where the problem is.

Also making sure the `artifacts/` dir exists and is used, since the artifacts from that failed run is a file (not a folder) that just contains the latest composer.json file contents.

## Issue
- https://github.com/silverstripe/.github/issues/307