### PR TITLE
FIX Don't try to install uninstallable libasound2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
             sudo add-apt-repository -y ppa:ondrej/apache2
             sudo apt update
             # The requirements from libnss3-dev are for chrome-testing to run properly
-            sudo apt install -y libapache2-mod-php${{ matrix.php }} libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
+            sudo apt install -y libapache2-mod-php${{ matrix.php }} libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev
 
             # ubuntu-latest comes with a current version of google-chrome-stable and chromedriver
             # however we want to use the https://developer.chrome.com/blog/chrome-for-testing/ to match


### PR DESCRIPTION
Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/11060345315/job/30730719567

> Package 'libasound2' has no installation candidate

`libasound2` isn't installable on its own for Ubuntu 24 which is the new `ubuntu:latest` in GitHub Actions, which is what we set all our CI to use.

I've read a bunch of places that people tried installing one of the packages that the error message says includes it, but they either couldn't install them or found they still had errors.

Tested this PR in https://github.com/creative-commoners/recipe-kitchen-sink/actions/runs/11061184264 and things are going green!
Remaining CI failures in that build aren't related.

## Issue
- https://github.com/silverstripe/.github/issues/313