### PR TITLE
FIX Don't exit with error for deleted patch-release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1054,6 +1054,36 @@ jobs:
         shell: bash
         id: dispatch-tag-patch-release
         run: |
+          # Check if the workflow currently exists. Without this, if the workflow USED to exist but was deleted,
+          # the response code for dispatching the workflow would be 422 instead of 404 so we can't rely on that.
+          # https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#list-repository-workflows
+          RESP_CODE=$(curl -w %{http_code} -s -L -o __response.json \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows
+          )
+          if [[ $RESP_CODE != "200" ]]; then
+            echo "Failed to get list of workflows - HTTP response code was $RESP_CODE"
+            cat __response.json
+            exit 1
+          fi
+
+          FOUND_WORKFLOW=0
+          WORKFLOWS=$(jq -r '.workflows[].path' __response.json)
+          while IFS= read -r WORKFLOW_PATH; do
+            if [[ "$WORKFLOW_PATH" == ".github/workflows/tag-patch-release.yml" ]]; then
+              echo "Found tag-patch-release.yml"
+              FOUND_WORKFLOW=1
+              break
+            fi
+          done <<< "$WORKFLOWS"
+
+          if [[ $FOUND_WORKFLOW == 0 ]]; then
+            echo "tag-patch-release.yml not present."
+            exit 0
+          fi
+
           # https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
           RESP_CODE=$(curl -w %{http_code} -s -L -o __response.json \
             -X POST \
@@ -1063,10 +1093,6 @@ jobs:
             https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/tag-patch-release.yml/dispatches \
             -d "{\"ref\":\"$BRANCH\",\"inputs\":{\"latest_local_sha\":\"${{ needs.tests.outputs.latest_local_sha }}\"}}"
           )
-          if [[ $RESP_CODE == "404" ]]; then
-            echo "tag-patch-release.yml not present."
-            exit 0
-          fi
           if [[ $RESP_CODE != "204" ]]; then
             echo "Failed to dispatch workflow - HTTP response code was $RESP_CODE"
             cat __response.json


### PR DESCRIPTION
Should finally fix https://github.com/silverstripe/recipe-testing/actions/runs/11133428791/job/30939770088 (and the same on all other recipes)
> Workflow does not have 'workflow_dispatch' trigger

GHA is pretending the workflow still exists because it used to exist but got deleted. So we have to explicitly check if it exists _before_ running the dispatch.

## Issue
- https://github.com/silverstripe/.github/issues/313