### PR TITLE
FIX Check workflow is active

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1070,7 +1070,7 @@ jobs:
           fi
 
           FOUND_WORKFLOW=0
-          WORKFLOWS=$(jq -r '.workflows[].path' __response.json)
+          WORKFLOWS=$(jq -r '.workflows[] | select(.state == "active") | .path' __response.json)
           while IFS= read -r WORKFLOW_PATH; do
             if [[ "$WORKFLOW_PATH" == ".github/workflows/tag-patch-release.yml" ]]; then
               echo "Found tag-patch-release.yml"


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/320

silverstripe/recipe-core builds are [failing](https://github.com/silverstripe/recipe-core/actions/runs/11152360312/job/31653517024) because it stubbornly insists that that a tag-patch-release.yml workflow exists, even though it's no where to be found in the repo anymore - https://api.github.com/repos/silverstripe/recipe-core/actions/workflows

I've manually disabled in it https://github.com/silverstripe/recipe-core/actions/workflows/tag-patch-release.yml - this shows up in the API under 'state', so filter on that