### PR TITLE
FIX Case insensitive match pre-stable versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -629,7 +629,7 @@ jobs:
                 if (strpos($v, "^") === 0) {
                   $v = str_replace("^", "", $v) . ".x-dev";
                   # Remove @beta, @rc, or @alpha if they are there
-                  $v = preg_replace("/@(alpha|beta|rc)/", "", $v);
+                  $v = preg_replace("/@(alpha|beta|rc)/i", "", $v);
                 }
                 $j->require->{"silverstripe/installer"} = $v;
                 $c = json_encode($j, JSON_PRETTY_PRINT + JSON_UNESCAPED_SLASHES);


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/320

Fixes https://github.com/silverstripe/recipe-blog/actions/runs/11155135600/job/31653137678

`Could not parse version constraint 5.3@RC.x-dev: Invalid version string "5.3@RC.x-dev"`