### PR TITLE
FIX Remove old apt sources entry before adding PHP PPA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,8 @@ jobs:
           # apt install extra requirements as required
           if [[ "${{ matrix.endtoend }}" == "true" ]]; then
             sudo apt install -y software-properties-common
+            # Remove legacy apt sources entry before installing PPA
+            [ -f /etc/apt/sources.list.d/ondrej-php.list ] && sudo rm /etc/apt/sources.list.d/ondrej-php.list
             sudo add-apt-repository -y ppa:ondrej/php
             sudo add-apt-repository -y ppa:ondrej/apache2
             sudo apt update


### PR DESCRIPTION
Fixes behat failures e.g https://github.com/silverstripe/silverstripe-elemental/actions/runs/14436226786/job/40477698067?pr=1347

```text
E: Conflicting values set for option Signed-By regarding source https://ppa.launchpadcontent.net/ondrej/php/ubuntu/ noble: /usr/share/keyrings/ondrej-php-keyring.gpg ...
```

As per https://www.srbu.se/articles/articles/add-ondrej-ppa-for-supported-php-extensions-on-ubuntu-24-04-lts and https://github.com/oerdnj/deb.sury.org/issues/2268 the new file name for the PPA sources file has a `.sources` extension. The file with the `.list` extension is no longer valid.

I'm not sure how that `.list` file gets there - might be part of `shivammathur/setup-php`, might be included in the runner by default, or might even be cached from previous runs somehow. Regardless of how it got there, removing it if it's there resolves the problem.

See https://github.com/creative-commoners/silverstripe-admin/actions/runs/14436880453 for a run that is using this patch and goes green.

## Issue
- https://github.com/silverstripe/.github/issues/389