### PR TITLE
FIX Install package after update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,8 +268,6 @@ jobs:
           AWS_DEFAULT_REGION: ap-southeast-2
         run: |
           if [[ "${{ matrix.endtoend }}" == "true" ]]; then
-            sudo apt install -y software-properties-common
-
             # ppa:ondrej/php appears to be already added, though ppa:ondrej/apache2 is not
             sudo add-apt-repository -y ppa:ondrej/apache2
 
@@ -278,8 +276,8 @@ jobs:
             # See https://manpages.debian.org/unstable/apt/apt-get.8.en.html under the `--allow-releaseinfo-change` heading
             sudo apt update --allow-releaseinfo-change-label
 
-            # The requirements from libnss3-dev are for chrome-testing to run properly
-            sudo apt install -y libapache2-mod-php${{ matrix.php }} libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev
+            # The requirements from libnss3-dev onwards are for chrome-testing to run properly
+            sudo apt install -y software-properties-common libapache2-mod-php${{ matrix.php }} libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev
 
             # ubuntu-latest comes with a current version of google-chrome-stable and chromedriver
             # however we want to use the https://developer.chrome.com/blog/chrome-for-testing/ to match


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/170

CMS 5.4 branches still use the `@v1` version of gha-ci. There's not need to update them to use v2 as far as I know, though if there is it would require a lot of module-standariser PR's and I'd prefer to not do that right now