### PR TITLE
FIX Run apt update for recipe-authoring tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,8 @@ jobs:
             rm chromedriver-linux64.zip
           fi
           if [[ $GITHUB_REPOSITORY =~ /(silverstripe-spellcheck|recipe-authoring-tools)$ ]] || [[ "${{ matrix.phpunit_suite }}" == "recipe-authoring-tools" ]]; then
+            # Need to update again otherwise apt will have issues finding dpkg-dev and libdpkg-perl
+            sudo apt update
             sudo apt install -y hunspell libhunspell-dev hunspell-en-us
           fi
           if [[ $GITHUB_REPOSITORY =~ /(silverstripe-dynamodb)$ ]] && [[ ${{ matrix.phpunit }} == "true" ]]; then


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/454

**DO NOT MERGE until https://github.com/silverstripe/gha-auto-tag/pull/30 has been merged, otherwise merging this PR will incorrectly update the v2 tag**

Fixes CI install issue that's specific to silverstripe/recipe-authoring-tools - https://github.com/silverstripe/recipe-authoring-tools/actions/runs/18177710112/job/51747246781#step:6:168

Have tested fix works https://github.com/emteknetnz/recipe-authoring-tools/actions/runs/18178306330/job/51748995918
